### PR TITLE
Update README's Usage steps

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,9 @@ Usage
 Briefcase can be used to wrap this as a standalone app under macOS::
 
     $ mkdir liquid
-    $ virtualenv --python=$(which python3)
-    $ pip install briefcase
+    $ python3 -m venv venv
+    $ source ./venv/bin/activate.bash  # Adjust accordingly for you shell.
+    $ python -m pip install briefcase
     $ git checkout http://github.com/pybee/liquid-demo.git
     $ cd liquid-demo
     $ python setup.py macos

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,7 @@ Usage
 Briefcase can be used to wrap this as a standalone app under macOS::
 
     $ mkdir liquid
+    $ cd liquid
     $ python3 -m venv venv
     $ source ./venv/bin/activate.bash  # Adjust accordingly for you shell.
     $ python -m pip install briefcase


### PR DESCRIPTION
List out the steps to use `venv`, activate the venv, and to not assume pip.